### PR TITLE
fix: correct Claude Code plugin schema for marketplace installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,9 +8,12 @@
     {
       "name": "lex-uk-law",
       "description": "UK legal research skill - search legislation, case law, and legal provisions",
-      "source": "local:skills/lex-uk-law",
+      "source": "./skills/lex-uk-law",
       "version": "1.0.0",
-      "author": "i.AI"
+      "author": {
+        "name": "i.AI",
+        "email": "lex@cabinetoffice.gov.uk"
+      }
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "lex-uk-law",
   "version": "1.0.0",
   "description": "UK legal research skill for Claude Code using the Lex API",
-  "author": "i.AI (Incubator for Artificial Intelligence)"
+  "author": {
+    "name": "i.AI (Incubator for Artificial Intelligence)",
+    "email": "lex@cabinetoffice.gov.uk"
+  }
 }


### PR DESCRIPTION
- Change `source` from "local:skills/lex-uk-law" to "./skills/lex-uk-law" (must start with "./" per schema requirements)
- Change `author` from string to object with name/email properties (schema expects object, not string)

These fixes allow the marketplace to be added via:
  claude plugin marketplace add i-dot-ai/lex
  claude plugin install lex-uk-law

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Brief description of the changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Related Issues
Fixes #(issue number)

## Testing
- [ ] Tests pass locally (`uv run pytest`)
- [ ] Code formatted (`ruff format` and `ruff check`)
- [ ] Manual testing completed

## Additional Notes
Any other information for reviewers. 