### PR TITLE
Add an example: serve Lex's MCP tools as a Bindu A2A agent (agno)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Connect AI assistants to Lex via Model Context Protocol. See the [live documenta
 - Microsoft Copilot Studio
 - VS Code + GitHub Copilot
 
+### Example: serve Lex as an A2A agent
+
+A community-contributed example wraps Lex's MCP tools in an [agno](https://github.com/agno-agi/agno) agent and exposes it over the [Bindu](https://github.com/GetBindu/Bindu) Agent-to-Agent protocol (DID identity + JSON-RPC endpoint). See [`examples/agno-bindu/`](examples/agno-bindu/).
+
 ## Local Development
 
 ### Prerequisites

--- a/examples/agno-bindu/.env.example
+++ b/examples/agno-bindu/.env.example
@@ -1,0 +1,14 @@
+# Required: an OpenRouter key (https://openrouter.ai/keys).
+OPENROUTER_API_KEY=sk-or-...        # pragma: allowlist secret
+
+# Optional overrides.
+BINDU_AGENT_MODEL=anthropic/claude-sonnet-4.5
+BINDU_AGENT_NAME=bindu-lex
+BINDU_AGENT_AUTHOR=you@example.com   # ends up in the public agent card / DID — set your own
+BINDU_AGENT_URL=http://localhost:3773
+
+# The hosted Lex MCP server. Only change this if you run your own Lex instance.
+LEX_MCP_URL=https://lex.lab.i.ai.gov.uk/mcp
+# LEX_MCP_TIMEOUT_SECONDS=60
+
+# BINDU_EXPOSE=true   # opens a PUBLIC, UNAUTHENTICATED tunnel — read the README first

--- a/examples/agno-bindu/.gitignore
+++ b/examples/agno-bindu/.gitignore
@@ -1,0 +1,9 @@
+.env
+.venv/
+tmp/
+__pycache__/
+*.db
+
+# Bindu generates the agent's DID keypair here at runtime — never commit it.
+.bindu/
+*.pem

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -1,0 +1,158 @@
+# Exposing Lex as a network-addressable Bindu agent
+
+This directory turns [Lex](https://github.com/i-dot-ai/lex) — the UK legal API and
+MCP server — into an **agent you can talk to over the network**. It wires Lex's
+hosted MCP tools into an [agno](https://github.com/agno-agi/agno) agent and serves
+that agent over the [Bindu](https://github.com/GetBindu/Bindu) A2A
+(Agent-to-Agent) protocol: a public agent card, a DID identity, and a JSON-RPC
+endpoint other agents and apps can call.
+
+> **Community-built example.** Not affiliated with or endorsed by the Lex / i.AI
+> maintainers. Lex is open source under its own [MIT LICENSE](../../LICENSE); this
+> directory is example glue showing one way to drive it. Lex describes its hosted
+> service as experimental and not for production use — treat this example the same
+> way.
+
+Contributed by the team at [Bindu](https://github.com/GetBindu/Bindu). Lex provides
+the real capability — 8.4M+ UK legal documents with semantic search; this example
+is the thin layer that lets an A2A network reach it. Bindu's examples index links
+back here so discovery flows both ways.
+
+## Maintenance
+
+The Lex data, API, and MCP tools are maintained by [i.AI](https://github.com/i-dot-ai/lex) —
+file tool/data issues there. For issues with *this example* (the Bindu glue, the
+prompt, this README), open an issue on [Bindu](https://github.com/GetBindu/Bindu)
+and tag it `[lex example]`, or reach the Bindu team on Discord.
+
+## What the example does
+
+You ask a question about UK law. The agno agent decides which Lex MCP tool to call
+— search for an Act, look one up by citation, pull its full text, read an
+explanatory note, or trace an amendment — calls it against the **hosted** Lex MCP
+server, and answers with citations. Because the model only answers from tool
+output, the responses are grounded in primary sources rather than the model's
+memory.
+
+There is no local Lex stack to run. Lex publishes a hosted MCP server, so the
+agent connects straight to it over HTTP — you only need a model key.
+
+It exposes 13 Lex tools, grouped as:
+
+- **Find legislation** — `search_for_legislation_acts`, `search_for_legislation_sections`
+- **Read legislation** — `lookup_legislation`, `get_legislation_sections`,
+  `get_legislation_full_text`, `proxy_legislation_data`
+- **Explanatory notes** — `search_explanatory_note`,
+  `get_explanatory_note_by_legislation`, `get_explanatory_note_by_section`
+- **Amendments** — `search_amendments`, `search_amendment_sections`
+- **Service** — `get_live_stats_api_stats_get`, `health_check_healthcheck_get`
+
+## The libraries it uses
+
+- **[agno](https://github.com/agno-agi/agno)** — the agent loop: model call,
+  tool-calling against MCP, and short-term memory.
+- **[Bindu](https://github.com/GetBindu/Bindu)** — wraps the agent as an A2A
+  service with a DID identity, an agent card, and a JSON-RPC endpoint.
+
+## Setup
+
+All commands use [`uv`](https://docs.astral.sh/uv/) and run from this directory.
+
+```bash
+uv venv
+uv pip install -r requirements.txt
+cp .env.example .env
+# edit .env and set OPENROUTER_API_KEY (https://openrouter.ai/keys)
+```
+
+That's the whole setup — the Lex MCP server is remote, so there is nothing else to
+install or ingest. The default model is `anthropic/claude-sonnet-4.5`; override it
+with `BINDU_AGENT_MODEL` in `.env`.
+
+> **Why `--no-project` below:** Lex is itself a `uv` project, so a bare `uv run`
+> would try to sync Lex's full dependency set. Running the example with
+> `uv run --no-project` keeps this small env (the `.venv` you just created here)
+> separate from Lex's — your Lex setup is untouched.
+
+## Run the CLI (one-shot)
+
+The fastest way to see it work — one question, rich-rendered, then exit:
+
+```bash
+uv run --no-project python cli.py "What does the Data Protection Act 2018 say about the rights of data subjects?"
+```
+
+The agent searches Lex, retrieves the relevant Act/sections, and answers with a
+`Sources` list of the legislation ids it used.
+
+## Run the A2A service (primary)
+
+```bash
+uv run --no-project python bindu_agent.py
+```
+
+This starts the Bindu agent on `http://localhost:3773` with:
+
+- `GET /.well-known/agent.json` — the agent card; the DID is published under
+  `capabilities.extensions[].uri` as `did:bindu:…`
+- `GET /.well-known/did.json` — the DID document
+- `GET /health` — health payload (`health: healthy`, `task_manager_running: true`,
+  and `application.agent_did`)
+- `POST /` — JSON-RPC 2.0: `message/send` (returns a task id with `state:
+  submitted`) and `tasks/get` (poll until `completed`)
+
+## Try it out
+
+`message/send` is asynchronous: it returns a task id, and you poll `tasks/get` for
+the answer. Each call needs **four UUIDs** (the JSON-RPC `id`, plus
+`messageId` / `contextId` / `taskId`), and the JSON-RPC `id` is validated as a UUID
+— so the snippet generates them. With the service running in another terminal:
+
+```bash
+BASE=http://localhost:3773
+uuid() { uuidgen | tr 'A-Z' 'a-z'; }
+RPC_ID=$(uuid); MSG_ID=$(uuid); CTX_ID=$(uuid); TASK_ID=$(uuid)
+
+# 1) send the question
+curl -s -X POST "$BASE" -H 'content-type: application/json' -d "{
+  \"jsonrpc\":\"2.0\",\"id\":\"$RPC_ID\",\"method\":\"message/send\",
+  \"params\":{
+    \"configuration\":{\"acceptedOutputModes\":[\"text/plain\"]},
+    \"message\":{
+      \"role\":\"user\",\"messageId\":\"$MSG_ID\",
+      \"contextId\":\"$CTX_ID\",\"taskId\":\"$TASK_ID\",
+      \"kind\":\"message\",
+      \"parts\":[{\"kind\":\"text\",\"text\":\"Which Act introduced the UK's right to be forgotten, and which section?\"}]
+    }
+  }
+}" >/dev/null
+
+# 2) poll until the task is done, then print the answer
+for i in $(seq 1 45); do
+  RESP=$(curl -s -X POST "$BASE" -H 'content-type: application/json' -d "{
+    \"jsonrpc\":\"2.0\",\"id\":\"$(uuid)\",\"method\":\"tasks/get\",
+    \"params\":{\"taskId\":\"$TASK_ID\"}
+  }")
+  STATE=$(printf '%s' "$RESP" | jq -r '.result.status.state // "?"')
+  echo "  [$i] $STATE"
+  case "$STATE" in completed|failed|input-required) break;; esac
+  sleep 2
+done
+printf '%s' "$RESP" | jq -r '.result.artifacts[0].parts[0].text // "(no answer text)"'
+```
+
+> **File uploads:** send your text as a `text` part, as above. Don't rely on A2A
+> file parts for PDFs/DOCX in this example — extract the text client-side first.
+
+## Network exposure & dependencies
+
+- **Local by default.** The service binds to `localhost` and CORS is limited to a
+  local origin. Nothing is published.
+- **`BINDU_EXPOSE=true` opens a PUBLIC, UNAUTHENTICATED tunnel** to your agent,
+  with your model key on the billing path. Only set it when you intend to share the
+  agent, and understand that anyone with the URL can spend your model budget.
+- **Opt-in dependencies.** Everything this example needs is in
+  `requirements.txt`; it adds nothing to Lex's own dependencies.
+- **Upstream service.** Answers come from the hosted Lex MCP server
+  (`https://lex.lab.i.ai.gov.uk/mcp`); point `LEX_MCP_URL` at your own instance if
+  you run one.

--- a/examples/agno-bindu/agent.py
+++ b/examples/agno-bindu/agent.py
@@ -1,0 +1,80 @@
+"""Lex UK Law Agent — the agent definition (no server started here).
+
+Consumed by cli.py (one-shot) and bindu_agent.py (A2A service, primary entry).
+
+Unlike a stdio MCP example, Lex runs a *hosted* MCP server, so there is nothing
+to install or launch locally: we point agno's MCPTools at the remote streamable
+HTTP endpoint (the same one Lex's own .mcp.json uses). The tools are attached to
+the agent when a connection is opened by the caller.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openrouter import OpenRouter
+from agno.tools.mcp import MCPTools
+from dotenv import load_dotenv
+from prompts import AGENT_DESCRIPTION, AGENT_NAME, SYSTEM_PROMPT
+
+HERE = Path(__file__).parent.resolve()
+
+# Load this example's .env deterministically, regardless of the current working
+# directory (so cli.py / bindu_agent.py started from the repo root still pick it
+# up). This must run before the model is built at import time below.
+load_dotenv(HERE / ".env")
+
+DB_PATH = HERE / "tmp" / "lex.db"
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+# The hosted Lex MCP server. Override via env only if you run your own instance.
+LEX_MCP_URL = os.getenv("LEX_MCP_URL", "https://lex.lab.i.ai.gov.uk/mcp")
+# Legal search over millions of documents can be slow; give it room.
+MCP_TIMEOUT_SECONDS = int(os.getenv("LEX_MCP_TIMEOUT_SECONDS", "60"))
+
+
+def make_mcp_tools() -> MCPTools:
+    """A fresh MCPTools bound to the hosted Lex MCP server.
+
+    Returns a new instance each call on purpose: an MCP session is tied to the
+    asyncio loop/task that opened it, so cli.py and bindu_agent.py each open their
+    own (see bindu_agent.py for how the A2A path keeps one warm).
+    """
+    return MCPTools(
+        url=LEX_MCP_URL,
+        transport="streamable-http",
+        timeout_seconds=MCP_TIMEOUT_SECONDS,
+    )
+
+
+def _build_model() -> OpenRouter:
+    model_id = os.getenv("BINDU_AGENT_MODEL", "anthropic/claude-sonnet-4.5")
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY is not set. Add it to your .env (see .env.example).")
+    return OpenRouter(
+        id=model_id,
+        api_key=api_key,
+        max_tokens=int(os.getenv("BINDU_AGENT_MAX_TOKENS", "4096")),
+    )
+
+
+def build_agent() -> Agent:
+    """Create the agent. Tools are attached when an MCP connection opens."""
+    return Agent(
+        name=AGENT_NAME,
+        description=AGENT_DESCRIPTION,
+        instructions=SYSTEM_PROMPT,
+        model=_build_model(),
+        db=SqliteDb(db_file=str(DB_PATH)),
+        add_history_to_context=True,
+        num_history_runs=3,
+        add_datetime_to_context=True,
+        markdown=True,
+    )
+
+
+agent: Agent = build_agent()  # module-level so cli.py and bindu_agent.py can import

--- a/examples/agno-bindu/bindu_agent.py
+++ b/examples/agno-bindu/bindu_agent.py
@@ -1,0 +1,102 @@
+"""Lex UK Law Agent exposed as a Bindu A2A agent.
+
+agno's MCPTools is async and its session is bound to the task that opened it, but
+Bindu calls the handler synchronously per request. So we run one asyncio loop in a
+daemon thread, open the MCP connection to the hosted Lex server **once** at boot,
+and marshal each handler call onto that loop. One warm connection serves every
+request instead of reconnecting each time.
+
+Run:  uv run --no-project python bindu_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import os
+import threading
+from pathlib import Path
+
+from agent import agent, make_mcp_tools
+from bindu.penguin.bindufy import bindufy
+from dotenv import load_dotenv
+from prompts import AGENT_DESCRIPTION
+
+# agent.py already loads this example's .env when imported above; load it again
+# here (harmless) so the BINDU_* config below resolves no matter the entry point.
+HERE = Path(__file__).resolve().parent
+load_dotenv(HERE / ".env")
+
+_loop = asyncio.new_event_loop()
+_mcp_tools = None
+_ready = threading.Event()
+
+
+def _run_loop() -> None:
+    asyncio.set_event_loop(_loop)
+    _loop.run_forever()
+
+
+threading.Thread(target=_run_loop, name="lex-mcp-loop", daemon=True).start()
+
+
+async def _open_mcp() -> None:
+    global _mcp_tools
+    _mcp_tools = make_mcp_tools()
+    await _mcp_tools.connect()
+    agent.tools = [_mcp_tools]
+
+
+asyncio.run_coroutine_threadsafe(_open_mcp(), _loop).result()
+_ready.set()
+
+
+def _shutdown() -> None:
+    if not _loop.is_running():
+        return
+    try:
+        if _mcp_tools is not None:
+            asyncio.run_coroutine_threadsafe(_mcp_tools.close(), _loop).result(timeout=5)
+    except Exception:
+        pass
+    _loop.call_soon_threadsafe(_loop.stop)
+
+
+atexit.register(_shutdown)
+
+
+async def _arun(content: str) -> str:
+    result = await agent.arun(content)
+    return result.content if hasattr(result, "content") else str(result)
+
+
+def handler(messages):
+    """Sync Bindu handler; hops the prompt onto the background loop. See gotchas.md.
+
+    Bindu normalizes the inbound A2A message to OpenAI-style
+    [{"role": "user"|"assistant", "content": "..."}] before calling us.
+    """
+    user_content = " ".join(
+        (m.get("content") or "") for m in (messages or []) if m.get("role") == "user"
+    ).strip()
+    if not user_content:
+        return "Send me a question about UK legislation and I'll look it up in Lex."
+    _ready.wait(timeout=30)
+    return asyncio.run_coroutine_threadsafe(_arun(user_content), _loop).result()
+
+
+config = {
+    "author": os.getenv("BINDU_AGENT_AUTHOR", "you@example.com"),
+    "name": os.getenv("BINDU_AGENT_NAME", "bindu-lex"),
+    "description": AGENT_DESCRIPTION,
+    "deployment": {
+        "url": os.getenv("BINDU_AGENT_URL", "http://localhost:3773"),
+        "expose": os.getenv("BINDU_EXPOSE", "false").lower() == "true",  # see README
+        "cors_origins": ["http://localhost:5173"],
+    },
+    "capabilities": {"streaming": False},
+}
+
+
+if __name__ == "__main__":
+    bindufy(config, handler)

--- a/examples/agno-bindu/cli.py
+++ b/examples/agno-bindu/cli.py
@@ -1,0 +1,49 @@
+"""One-shot CLI for the Lex UK Law Agent.
+
+    uv run --no-project python cli.py "What does the Data Protection Act 2018 cover?"
+
+Opens its own MCP connection for a single question and exits — no background loop
+needed here (that lives in bindu_agent.py for the long-running A2A service).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from agent import agent, make_mcp_tools  # importing agent loads this example's .env
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.rule import Rule
+
+console = Console()
+err = Console(stderr=True)
+
+
+async def ask(question: str) -> str:
+    async with make_mcp_tools() as mcp_tools:
+        agent.tools = [mcp_tools]
+        result = await agent.arun(question)
+        return result.content if hasattr(result, "content") else str(result)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        err.print('[bold red]Error:[/bold red] pass a question, e.g. cli.py "..."')
+        return 2
+    question = " ".join(sys.argv[1:])
+    console.print(Panel.fit(question, title="Question", border_style="cyan"))
+    try:
+        with err.status("[bold cyan]Researching UK law…[/bold cyan]", spinner="dots"):
+            answer = asyncio.run(ask(question))
+    except Exception as exc:
+        err.print(f"[bold red]Error:[/bold red] {exc}")
+        return 1
+    console.print(Rule(style="dim"))
+    console.print(Markdown(answer))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agno-bindu/prompts.py
+++ b/examples/agno-bindu/prompts.py
@@ -1,0 +1,118 @@
+"""System prompt and identity for the Lex UK Law agent.
+
+Kept in one place so cli.py and bindu_agent.py share exactly the same brain.
+The <available_tools> block mirrors the 13 tools the hosted Lex MCP server
+exposes (https://lex.lab.i.ai.gov.uk/mcp); keep it in sync if Lex changes.
+"""
+
+from textwrap import dedent
+
+AGENT_NAME = "Lex UK Law Agent"
+
+AGENT_DESCRIPTION = (
+    "Answers questions about UK legislation, statutory instruments, explanatory "
+    "notes, and amendments, grounded in the Lex API (8.4M+ UK legal documents) "
+    "over the Model Context Protocol. Community-built example. Not affiliated with "
+    "or endorsed by the Lex / i.AI maintainers."
+)
+
+SYSTEM_PROMPT = dedent(
+    """\
+    You are the Lex UK Law Agent, a research assistant for UK law. You are a
+    community-built example, not affiliated with or endorsed by the Lex / i.AI
+    maintainers.
+
+    You operate MCP-first: every substantive answer must be grounded in a tool
+    call against the Lex MCP server, never your own training memory. UK law is
+    large and changes often; treat the tools as the source of truth and treat your
+    prior knowledge as, at best, a hint about which tool to call.
+
+    <tool_calling>
+    1. Only call tools when needed to ground the answer in a primary source.
+    2. If you tell the user you will look something up, issue the tool call as your
+       very next action.
+    3. Follow each tool's schema exactly; never invent parameters or fields.
+    4. Never call a tool that is not listed in <available_tools>.
+    5. Prefer the cheapest precise call, and chain in the obvious order:
+       search -> lookup/get -> (notes / amendments) as the question demands.
+    6. Legislation is addressed by an id of the form {type}/{year}/{number}
+       (e.g. ukpga/2018/12 = the Data Protection Act 2018). Carry that id forward
+       from a search result into the follow-up get/lookup call rather than guessing.
+    7. On an error or empty result, read the message, adjust the query (broaden
+       terms, drop filters, widen the year range) and try once more; do not retry
+       blindly or fabricate a result.
+    8. Never fabricate legislation ids, section numbers, citations, or quotes.
+    </tool_calling>
+
+    <available_tools>
+    Discovery — find the right legislation:
+      search_for_legislation_acts(query, year_from?, year_to?, legislation_type?,
+        offset?, limit?, include_text?)
+        -> find whole Acts / Statutory Instruments by title, topic, or content.
+        Start here for "what law covers X?".
+      search_for_legislation_sections(query, legislation_id?, legislation_category?,
+        legislation_type?, year_from?, year_to?, offset?, size?, include_text?)
+        -> find specific provisions/text within sections. Use for "which section
+        says X?" or to search inside one Act (pass legislation_id).
+
+    Retrieval — read a specific piece of legislation:
+      lookup_legislation(legislation_type, year, number)
+        -> fetch one Act/SI by its official citation parts (e.g. ukpga, 2018, 12).
+      get_legislation_sections(legislation_id, limit?)
+        -> the full section-by-section structure and content of one piece.
+      get_legislation_full_text(legislation_id, include_schedules?)
+        -> the entire text of an Act/SI as a single document.
+      proxy_legislation_data(legislation_id)
+        -> enriched metadata fetched live from legislation.gov.uk.
+
+    Explanatory notes — intent and context:
+      search_explanatory_note(query?, legislation_id?, note_type?, section_type?, size?)
+      get_explanatory_note_by_legislation(legislation_id, limit?)
+      get_explanatory_note_by_section(legislation_id, section_number)
+        -> use when the user asks what a provision means, why it exists, or how it
+        is meant to operate.
+
+    Amendments — how the law has changed:
+      search_amendments(legislation_id, search_amended?, size?)
+        -> amendments affecting (or made by) a piece of legislation.
+      search_amendment_sections(provision_id, search_amended?, size?)
+        -> amendment detail at the level of a specific provision.
+
+    Service:
+      get_live_stats_api_stats_get()  -> live dataset coverage/counts.
+      health_check_healthcheck_get()  -> service health (rarely user-facing).
+
+    Selection guide:
+      "What does UK law say about X?"        -> search_for_legislation_acts, then
+                                                get_legislation_full_text / _sections.
+      "Find the provision about X"            -> search_for_legislation_sections.
+      "Show me {Act} {year} c.{n}"           -> lookup_legislation.
+      "What does section N mean / why?"       -> explanatory note tools.
+      "Has {Act} been amended?"               -> search_amendments.
+      "How much data do you cover?"           -> get_live_stats_api_stats_get.
+    </available_tools>
+
+    <handling_uncertainty>
+    Ambiguity — ask before you search. If a request names a *kind* of legislation
+    that exists in many annual or numbered instances (e.g. "the Finance Act", "the
+    Companies Act", "the Education Act") without saying which year or which one, do
+    NOT call a tool and do NOT answer generically about the category. Ask ONE
+    targeted question that names the ambiguity (e.g. "There's a Finance Act almost
+    every year — which year do you mean?") and stop. Do the same when the UK
+    jurisdiction or the specific provision is unclear and it would change the answer.
+    Out of scope — if the request is not about UK legislation/law, or the tools
+    cannot answer it, say so plainly and briefly; do not call a tool.
+    You provide legal information, not legal advice; when a question seeks advice on
+    a specific situation, give the relevant law and add a short reminder to consult
+    a qualified professional.
+    </handling_uncertainty>
+
+    <communication_style>
+    Be concise. Use second person for the user and first person for yourself.
+    Mirror the user's language. Use GitHub-flavored Markdown. Lead with the direct
+    answer, then the citation (legislation id + title + section), then any brief
+    reasoning, and finish with a "Sources" list of the legislation ids you relied
+    on. Quote statutory text sparingly and accurately, only from tool output.
+    </communication_style>
+    """
+)

--- a/examples/agno-bindu/requirements.txt
+++ b/examples/agno-bindu/requirements.txt
@@ -1,0 +1,10 @@
+# Python deps for the agno + Bindu glue. The Lex MCP server is hosted, so there is
+# nothing from the parent repo to install — see this example's README for setup.
+bindu>=2026.20
+agno>=2.6,<3
+openai>=1.40
+mcp>=1.0           # agno's MCP client (streamable HTTP transport to the hosted Lex server)
+sqlalchemy>=2
+aiosqlite>=0.20
+python-dotenv>=1.0
+rich>=13


### PR DESCRIPTION
## What this pull request adds

One new directory, `examples/agno-bindu/`, plus two short pointer lines under the
existing "MCP Integration" heading in `README.md`. The example wraps Lex's hosted
MCP tools in a small [agno](https://github.com/agno-agi/agno) agent and serves that
agent over the [Bindu](https://github.com/GetBindu/Bindu) A2A (Agent-to-Agent)
protocol — so other agents and apps can reach Lex through a network-addressable
endpoint with a cryptographic (DID) identity, not just an interactive MCP client.

It is purely additive:

- No code under `src/` is touched, and CI is unchanged.
- The extra Python packages live in `examples/agno-bindu/requirements.txt` and are
  opt-in — installed into a local `.venv` inside the example directory.
- The agent talks to **your hosted MCP server** (`https://lex.lab.i.ai.gov.uk/mcp`,
  the same endpoint your `.mcp.json` already points at), so there's no new service
  to run and no change to how Lex is deployed.

## Who is contributing this

Contributed by the team at [Bindu](https://github.com/GetBindu/Bindu), an open
framework for building decentralised AI agents that speak the A2A protocol with
DID-based identity. This sits in our showcase of "agents that wrap a great upstream
tool"; Lex is the source of the actual capability here, and the example treats it
as the source of truth. We'll link back to this repo from Bindu's examples index so
discovery flows both ways.

## How the example is shaped

- **A2A over JSON-RPC**, with a DID identity and a public agent card. `agno`
  provides the agent loop (model call, tool-calling against MCP, short-term memory).
- Because Lex's MCP server is **hosted**, the agent connects to the remote
  streamable-HTTP endpoint rather than launching a subprocess. A single asyncio loop
  in a daemon thread opens that MCP connection **once** at start-up and reuses it for
  every request (one warm connection, not one per call).
- Two entry points: `bindu_agent.py` (the primary A2A service) and `cli.py` (a
  one-shot local runner for quick checks).

## The API surface

With the service running on `http://localhost:3773`:

- `GET /.well-known/agent.json` — the agent card; the DID is published under
  `capabilities.extensions[].uri` as `did:bindu:…`.
- `GET /.well-known/did.json` — the DID document.
- `GET /health` — health payload, including `application.agent_did`.
- `POST /` — JSON-RPC 2.0: `message/send` returns a task id with `state: submitted`;
  poll `tasks/get` until `completed`. (`message/send` carries four UUIDs — the
  JSON-RPC `id` plus `messageId` / `contextId` / `taskId`, and the `id` is validated
  as a UUID.) The example README has a copy-paste snippet that generates the UUIDs
  and polls for the answer.

## How the agent is instructed

The system prompt keeps the agent disciplined:

1. **MCP-first** — every substantive answer must be grounded in a Lex tool call,
   never the model's training memory.
2. **Stable identifiers** — address legislation by `{type}/{year}/{number}`
   (e.g. `ukpga/2018/12`) and carry that id from a search result into the follow-up
   `get`/`lookup` call instead of guessing.
3. **Cheapest precise call** — chain `search` → `get`/notes/amendments in the obvious
   order; never call a tool that isn't in the agent's tool list.
4. **Cite** — lead with the answer, then the citation (id + title + section), then a
   short `Sources` list; quote statutory text only from tool output.
5. **Know its limits** — on an ambiguous "which Act?" request (e.g. "the Finance
   Act"), ask one clarifying question and stop, with no tool call; decline
   out-of-scope questions plainly; give legal information, not advice.

## End-to-end verification

Run against `bindu==2026.21.2`, model `anthropic/claude-sonnet-4.5` via OpenRouter,
talking to the live Lex MCP server (`Lex API v3.2.0`). Each example was run **both**
through the agno/CLI path and the **live A2A service** (`message/send` → poll
`tasks/get`). The agent card DID (`did:bindu:…:bindu-lex:…`) and `/health` were
verified independently, and a single warm HTTP MCP connection served all the A2A
calls.

| # | Question | Tool(s) called | A2A state | Result |
|---|----------|----------------|-----------|--------|
| 1 | Data Protection Act 2018 — data-subject rights? | `lookup_legislation`, `search_for_legislation_sections` | completed | Rights cited by section, `ukpga/2018/12` |
| 2 | Look up `ukpga/2018/12` — short title + scope | `lookup_legislation` | completed | "Data Protection Act 2018" + summary |
| 3 | Which Act/section = offence of unauthorised access to computer material? | `search_for_legislation_sections` | completed | Computer Misuse Act 1990 (`ukpga/1990/18`), s.1 |
| 4 | Online Safety Act 2023 — purpose per explanatory notes? | `search_explanatory_note` | completed | OSA 2023 (`ukpga/2023/50`) purpose, quoted from notes |
| 5 | Has the Data Protection Act 1998 been repealed/amended? | `search_amendments` | completed | Repealed by DPA 2018; amendment history |
| 6 | How much legislation does the dataset cover? | `get_live_stats_api_stats_get` | completed | 219,943 Acts/SIs; 2,533,903 amendments |
| 7 | "What's the capital of France?" (out of scope) | _none_ | completed | Declines, redirects to UK law — **no tool call** |
| 8 | "What does the Finance Act cover?" (ambiguous) | _none_ | completed | Asks "which year?" — **no tool call** |

## Test plan for review

All `uv`, from the example directory (`examples/agno-bindu/`). Lex is itself a `uv`
project, so the example is run with `--no-project` to keep its small env separate
from Lex's — your Lex setup is untouched.

```bash
cd examples/agno-bindu
uv venv
uv pip install -r requirements.txt
cp .env.example .env          # set OPENROUTER_API_KEY (https://openrouter.ai/keys)

# one-shot
uv run --no-project python cli.py "What does the Data Protection Act 2018 cover?"

# A2A service
uv run --no-project python bindu_agent.py
# then, in another shell:
curl -s http://localhost:3773/health | jq '.health, .application.agent_did'
curl -s http://localhost:3773/.well-known/agent.json | jq '.capabilities.extensions[].uri'
# + the message/send → tasks/get snippet in examples/agno-bindu/README.md
```

## A note to the maintainers

This is additive, not a request for major changes. If you'd prefer a different
structure — moving the example to a separate repo under the Bindu org, a different
place for the README pointer, or no README change at all — we're glad to adjust.

One thing we've called out honestly in the example's README: it depends on your
**hosted** MCP service, which you describe as experimental and not for production.
That's a deliberate fit for an example (it's how your `.mcp.json` consumes Lex too),
and the README says so plainly. Thank you for open-sourcing Lex — the tool surface
made this a pleasure to build on.
