### PR TITLE
fix: skip empty-text documents during upload

### DIFF
--- a/src/lex/core/document.py
+++ b/src/lex/core/document.py
@@ -132,9 +132,10 @@ def upload_documents(
                                 text_parts.append(str(value))
                         text = " ".join(text_parts)
 
-                    if not text:
+                    if not text or not text.strip():
                         logger.warning(
-                            f"Document {doc_id} has no content in embedding fields {embedding_fields}, skipping",
+                            f"Document {doc_id} has no content in embedding fields "
+                            f"{embedding_fields}, skipping",
                             extra={
                                 "doc_id": doc_id,
                                 "collection": collection_name,
@@ -143,8 +144,21 @@ def upload_documents(
                         )
                         continue
 
+                    text = text.strip()
                     texts.append(text)
                     doc_metadata.append((doc_id, doc))
+
+                if not texts:
+                    logger.warning(
+                        f"No uploadable documents in batch {i}; all documents had empty content",
+                        extra={
+                            "batch_number": i,
+                            "batch_size": len(batch),
+                            "collection": collection_name,
+                            "embedding_fields": embedding_fields,
+                        },
+                    )
+                    break
 
                 # Generate dense embeddings in batch (sparse is computed server-side by Qdrant)
                 from lex.core.embeddings import bm25_document, generate_dense_embeddings_batch

--- a/tests/lex/core/test_document.py
+++ b/tests/lex/core/test_document.py
@@ -1,0 +1,74 @@
+from pydantic import BaseModel
+
+from lex.core import document as document_module
+from lex.core.document import upload_documents
+
+
+class UploadDocument(BaseModel):
+    id: str
+    text: str
+
+
+class FakeQdrantClient:
+    def __init__(self) -> None:
+        self.upsert_calls = []
+
+    def upsert(self, **kwargs):
+        self.upsert_calls.append(kwargs)
+
+
+class FakePointStruct:
+    def __init__(self, id, vector, payload):
+        self.id = id
+        self.vector = vector
+        self.payload = payload
+
+
+def test_upload_documents_skips_empty_batch_without_embedding(monkeypatch):
+    embedding_calls = []
+    qdrant_client = FakeQdrantClient()
+
+    monkeypatch.setattr(
+        "lex.core.embeddings.generate_dense_embeddings_batch",
+        lambda texts, max_workers=25: embedding_calls.append(texts) or [[0.1] for _ in texts],
+    )
+    monkeypatch.setattr("lex.core.embeddings.bm25_document", lambda text: text)
+    monkeypatch.setattr(document_module, "qdrant_client", qdrant_client)
+    monkeypatch.setattr(document_module, "PointStruct", FakePointStruct)
+
+    upload_documents(
+        collection_name="test",
+        documents=[UploadDocument(id="empty", text="")],
+        batch_size=1,
+    )
+
+    assert embedding_calls == []
+    assert qdrant_client.upsert_calls == []
+
+
+def test_upload_documents_skips_empty_documents_and_uploads_valid_ones(monkeypatch):
+    embedding_calls = []
+    qdrant_client = FakeQdrantClient()
+
+    monkeypatch.setattr(
+        "lex.core.embeddings.generate_dense_embeddings_batch",
+        lambda texts, max_workers=25: embedding_calls.append(texts) or [[0.1] for _ in texts],
+    )
+    monkeypatch.setattr("lex.core.embeddings.bm25_document", lambda text: text)
+    monkeypatch.setattr(document_module, "qdrant_client", qdrant_client)
+    monkeypatch.setattr(document_module, "PointStruct", FakePointStruct)
+
+    upload_documents(
+        collection_name="test",
+        documents=[
+            UploadDocument(id="empty", text=""),
+            UploadDocument(id="whitespace", text="   "),
+            UploadDocument(id="valid", text=" useful content "),
+        ],
+        batch_size=3,
+    )
+
+    assert embedding_calls == [["useful content"]]
+    assert len(qdrant_client.upsert_calls) == 1
+    assert len(qdrant_client.upsert_calls[0]["points"]) == 1
+    assert qdrant_client.upsert_calls[0]["points"][0].payload["id"] == "valid"

--- a/tests/lex/core/test_document.py
+++ b/tests/lex/core/test_document.py
@@ -46,7 +46,7 @@ def test_upload_documents_skips_empty_batch_without_embedding(monkeypatch):
     assert qdrant_client.upsert_calls == []
 
 
-def test_upload_documents_skips_empty_documents_and_uploads_valid_ones(monkeypatch):
+def test_upload_documents_skips_empty_batch_and_uploads_later_valid_documents(monkeypatch, caplog):
     embedding_calls = []
     qdrant_client = FakeQdrantClient()
 
@@ -65,10 +65,13 @@ def test_upload_documents_skips_empty_documents_and_uploads_valid_ones(monkeypat
             UploadDocument(id="whitespace", text="   "),
             UploadDocument(id="valid", text=" useful content "),
         ],
-        batch_size=3,
+        batch_size=2,
     )
 
     assert embedding_calls == [["useful content"]]
     assert len(qdrant_client.upsert_calls) == 1
     assert len(qdrant_client.upsert_calls[0]["points"]) == 1
     assert qdrant_client.upsert_calls[0]["points"][0].payload["id"] == "valid"
+    assert (
+        sum("No uploadable documents in batch" in record.message for record in caplog.records) == 1
+    )


### PR DESCRIPTION
## Summary

- skip documents whose embedding text is empty or only whitespace
- avoid calling embedding generation or Qdrant upsert when a batch has no uploadable documents
- keep processing later batches after an empty batch without retrying the empty batch
- add focused tests for empty-only and empty-before-valid batches

Fixes #5.

## Validation

```bash
uv sync --frozen
uv run --frozen pytest tests/lex/core/test_document.py -q
uv run --frozen ruff check src/lex/core/document.py tests/lex/core/test_document.py
uv run --frozen ruff format --check src/lex/core/document.py tests/lex/core/test_document.py
```

Results:

- 2 tests passed
- Ruff lint passed
- both changed files were already correctly formatted

The cross-batch test uses an empty first batch and a valid document in the next batch. It verifies that the valid document is uploaded and the empty-batch warning is emitted exactly once. Fault-injecting `continue` in place of the retry-loop `break` made the warning repeat five times and caused the test to fail, confirming that the test protects both forward progress and retry behavior.

## AI assistance

AI assistance was used to inspect the retry-loop control flow, strengthen the cross-batch regression test, run fault-injection validation, and refine this PR description. The resulting change and validation evidence were reviewed before submission.
