### PR TITLE
docs: add troubleshooting for mcp-remote Node.js version crash

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,6 +39,50 @@ If Claude Desktop or other MCP clients can't connect:
 2. Check the MCP endpoint: `curl http://localhost:8000/mcp`
 3. Ensure your configuration file has the correct URL
 
+## MCP client crashes with `ReferenceError: File is not defined`
+
+If your client launches `mcp-remote` via `npx` and exits immediately with:
+
+```
+ReferenceError: File is not defined
+    at .../node_modules/undici/lib/web/webidl/index.js
+```
+
+it is running under Node.js 18 or older. `mcp-remote` depends on `undici`, which
+needs the `File` global added in Node.js 20.
+
+This usually happens when nvm is installed. Clients such as Claude Desktop build
+their own `PATH` for the processes they spawn, and an nvm Node can take
+precedence over a newer system one. Giving the full path to `npx` does not help,
+because the spawned process still inherits that `PATH`.
+
+Lex serves MCP over Streamable HTTP, so the simplest fix is to skip `mcp-remote`
+and connect directly. In Claude Code:
+
+```bash
+claude mcp add --transport http lex https://lex.lab.i.ai.gov.uk/mcp
+```
+
+For a client that can only launch a command, point it at a wrapper script that
+puts a Node.js 20+ install first on `PATH`:
+
+```bash
+#!/bin/bash
+# ~/.local/bin/mcp-remote-wrapper
+export PATH="/opt/homebrew/bin:$PATH"
+exec /opt/homebrew/bin/npx -y mcp-remote@latest "$@"
+```
+
+```json
+{
+  "command": "/Users/<username>/.local/bin/mcp-remote-wrapper",
+  "args": ["https://lex.lab.i.ai.gov.uk/mcp"]
+}
+```
+
+To confirm which version a wrapper resolves to, add `node --version` to the
+script — the client's `PATH` is often not the one your shell uses.
+
 ## Embedding model issues
 
 If you see errors about embeddings or Azure OpenAI:


### PR DESCRIPTION
## Description

Adds a troubleshooting entry for the `ReferenceError: File is not defined` crash reported in #13, where an MCP client launching `mcp-remote` via `npx` exits immediately on startup.

The underlying cause sits in `mcp-remote`'s dependency `undici`, which needs the `File` global added in Node.js 20. What makes it worth documenting on the Lex side is the non-obvious part: it usually only bites when nvm is installed, and pointing the config at a full `npx` path *doesn't* fix it, because the spawned process still inherits the client's own `PATH` where an nvm Node can take precedence. That is easy to lose an afternoon to.

The entry covers the symptom and two ways out:

- Connecting over Streamable HTTP directly (`claude mcp add --transport http lex ...`), which sidesteps `mcp-remote` entirely. The reporter confirmed on the issue that this path works.
- A wrapper script that fixes `PATH`, for clients that can only launch a command.

Scoped deliberately to docs. Of the three fixes the reporter suggested, a startup version check belongs in `mcp-remote` and honouring the `env` key belongs to the client, so documenting the conflict is the part that's actionable in this repo — which is also what they listed as option 3.

## Type of Change
- [x] Documentation

## Related Issues

Refs #13

Left as "Refs" rather than "Fixes" on purpose: this documents the workaround but the upstream crash in `mcp-remote` is still there, so you may want to keep the issue open or close it deliberately.

## Testing
- [ ] Tests pass locally (`uv run pytest`) — n/a, no code changed
- [ ] Code formatted (`ruff format` and `ruff check`) — n/a, markdown only
- [x] Manual testing completed — verified the command and config against the issue report and the existing docs; no IPs, secrets or account IDs added, so the `pre-commit` scanners are unaffected

## Additional Notes

I wrote this from the detail in #13 plus the repo's existing docs rather than from hitting the crash myself, so the specifics are the reporter's. Two things worth a maintainer's eye:

- The wrapper example uses the Homebrew path from the report (`/opt/homebrew/bin`, Apple Silicon). Fine as an illustration, but it is macOS-shaped.
- I put it in `docs/troubleshooting.md` under its own heading next to the existing "MCP connection issues" section. If the live docs at `lex.lab.i.ai.gov.uk/docs` are the place users actually land for MCP setup, this may be worth mirroring there too — happy to follow up if you point me at the source.

Also, unrelated to this PR but noticed while reading the repo: #5 describes an Elastic ingest failure, and Elastic looks to have been replaced by Qdrant since (no `elasticsearch` dependency in `pyproject.toml`). I'll leave a note on that issue separately rather than mixing it in here.